### PR TITLE
Handle errors

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -16,6 +16,7 @@ function useDockerDesktopClient() {
 
 function App() {
   const [responses, setResponses] = React.useState([]);
+  const [errors, setErrors] = React.useState("");
   const ddClient = useDockerDesktopClient();
   const editorRef = React.useRef(null);
 
@@ -29,6 +30,7 @@ function App() {
       code,
     });
     setResponses(result.Events);
+    setErrors(result.Errors);
   };
 
   return (
@@ -52,10 +54,16 @@ function App() {
         <Button onClick={run}>Run</Button>
       </div>
       <div>
-        {responses.map((response) => (
-          <pre key={response.Message}>{response.Message}</pre>
-        ))}
+        {responses &&
+          responses.map((response) => (
+            <pre key={response.Message}>{response.Message}</pre>
+          ))}
       </div>
+      {errors && (
+        <pre style={{ color: "red" }} key={errors}>
+          {errors}
+        </pre>
+      )}
     </DockerMuiThemeProvider>
   );
 }


### PR DESCRIPTION
When running code that has compilation errors, the extension fails by displaying a blank page that cannot be used anymore.

This PR handle the compilation errors by showing them in red just below the code editor.

![image](https://user-images.githubusercontent.com/15997951/168552819-20c68b2e-985d-45ea-8320-4e3994be3d9e.png)
